### PR TITLE
0,0,0や直径0などのエラー対応、norm修正、ファイル分割、header修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ MINILIBX_FLAGS = -Lmlx -lmlx -framework OpenGL -framework AppKit
 SRCS_DIR = src
 SRC = main.c \
 	parse.c \
+	parse_check.c \
 	parse_objs.c \
 	parse_utils.c \
 	parse_settings.c \

--- a/include/parse.h
+++ b/include/parse.h
@@ -5,10 +5,11 @@
 /*                                                    +:+ +:+         +:+     */
 /*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/09/30 14:59:20 by tterao            #+#    #+#             */
-/*   Updated: 2023/10/09 21:08:33 by ryhara           ###   ########.fr       */
+/*   Created: Invalid date        by                   #+#    #+#             */
+/*   Updated: 2023/10/10 10:14:11 by ryhara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
+
 
 #ifndef PARSE_H
 # define PARSE_H
@@ -36,26 +37,36 @@
 # define ARR_SIZE_PL 10
 # define ARR_SIZE_CY 12
 
-
-void				global_data_init(t_global_data *data);
+// error.c
+void				put_error(const char *name);
+// free.c
 void				global_data_free(t_global_data *data);
-bool				parse(t_global_data *data, const char *file);
+void				free_data_and_puterr(t_global_data *data, const char *message);
+void				free_char_array(char **array);
+// init.c
+void				global_data_init(t_global_data *data);
 t_ambient_lightning	*ambient_light_init(const char **info);
 t_camera			*camera_init(const char **info);
 t_light				*light_init(const char **info);
-
-char				**parse_ambient_light(const char *line);
-char				**parse_camera(const char *line);
-char				**parse_light(const char *line);
+// parse_check.c
+bool				check_line(const char *line);
+bool				check_exist_a_c_l(t_global_data *data);
+bool				check_vector_valid(char **info, size_t start, size_t end);
+char				**parse_check(const char *line);
+// parse_objs.c
 char				**parse_sphere(const char *line);
 char				**parse_plane(const char *line);
 char				**parse_cylinder(const char *line);
-
+// parse_settings.c
+char				**parse_ambient_light(const char *line);
+char				**parse_camera(const char *line);
+char				**parse_light(const char *line);
+// parse_utils.c
 bool				check_range_float(float num, float min, float max);
 bool				check_range_int(int num, int min, int max);
 size_t				get_array_size(char **array);
-void				free_char_array(char **array);
 bool				check_color_range(char **info, size_t start, size_t end);
-void				free_data_and_puterr(t_global_data *data, const char *message);
+// parse.c
+bool				parse(t_global_data *data, const char *file);
 
 #endif

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/30 17:42:27 by tterao            #+#    #+#             */
-/*   Updated: 2023/10/08 17:19:49 by ryhara           ###   ########.fr       */
+/*   Updated: 2023/10/10 09:49:24 by ryhara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,4 +29,19 @@ void	free_data_and_puterr(t_global_data *data, const char *message)
 	ft_dprintf(STDERR_FILENO, "\n");
 	global_data_free(data);
 	exit(1);
+}
+
+void	free_char_array(char **array)
+{
+	size_t	i;
+
+	i = 0;
+	while (array[i])
+	{
+		free(array[i]);
+		array[i] = NULL;
+		i++;
+	}
+	free(array);
+	array = NULL;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -6,29 +6,12 @@
 /*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/30 15:35:48 by ryhara            #+#    #+#             */
-/*   Updated: 2023/10/08 17:03:54 by ryhara           ###   ########.fr       */
+/*   Updated: 2023/10/10 09:59:43 by ryhara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parse.h"
-
-static char	**_parse_check(const char *line)
-{
-	if (!ft_strncmp(MP_AMIBIENT_LIGHT, line, 2))
-		return (parse_ambient_light(line));
-	else if (!ft_strncmp(MP_CAMERA, line, 2))
-		return (parse_camera(line));
-	else if (!ft_strncmp(MP_LIGHT, line, 2))
-		return (parse_light(line));
-	else if (!ft_strncmp(MP_SPHERE, line, 3))
-		return (parse_sphere(line));
-	else if (!ft_strncmp(MP_PLANE, line, 3))
-		return (parse_plane(line));
-	else if (!ft_strncmp(MP_CYLINDER, line, 3))
-		return (parse_cylinder(line));
-	else
-		return (NULL);
-}
+#define INVALID_ERR "Error\nInvalid format\n"
 
 static void	_parse_to_init(t_global_data *data, const char **info)
 {
@@ -58,7 +41,7 @@ static void	_parse_to_init(t_global_data *data, const char **info)
 		objs_addback(data->objs_list, objs_newnode(CYLINDER, info));
 }
 
-static int	parse_open(t_global_data *data, const char *file)
+static int	_parse_open(t_global_data *data, const char *file)
 {
 	size_t	i;
 	int		fd;
@@ -77,7 +60,7 @@ static int	parse_open(t_global_data *data, const char *file)
 		return (free_data_and_puterr(data, "Please input *.rt file."), -1);
 }
 
-bool	parse_loop(t_global_data *data, int fd)
+static bool	_parse_loop(t_global_data *data, int fd)
 {
 	char	*line;
 	char	**info;
@@ -94,12 +77,12 @@ bool	parse_loop(t_global_data *data, int fd)
 			free(line);
 			continue ;
 		}
-		info = _parse_check(line);
+		info = parse_check(line);
 		if (info == NULL)
 		{
 			free(line);
 			global_data_free(data);
-			return (ft_dprintf(STDERR_FILENO, "Error\nInvalid format\n"), false);
+			return (ft_dprintf(STDERR_FILENO, INVALID_ERR), false);
 		}
 		free(line);
 		_parse_to_init(data, (const char **)info);
@@ -111,27 +94,16 @@ bool	parse_loop(t_global_data *data, int fd)
 	return (true);
 }
 
-bool	check_exist_A_C_L(t_global_data *data)
-{
-	if (data->ambient_light == NULL)
-		return (free_data_and_puterr(data, "A does not exist"), false);
-	if (data->camera == NULL)
-		return (free_data_and_puterr(data, "C does not exist"), false);
-	if (data->light == NULL)
-		return (free_data_and_puterr(data, "L does not exist"), false);
-	return (true);
-}
-
 bool	parse(t_global_data *data, const char *file)
 {
 	int		fd;
 
-	fd = parse_open(data, file);
+	fd = _parse_open(data, file);
 	if (fd == -1)
 		return (false);
-	if (!parse_loop(data, fd))
+	if (!_parse_loop(data, fd))
 		return (false);
-	if (!check_exist_A_C_L(data))
+	if (!check_exist_a_c_l(data))
 		return (false);
-	return(true);
+	return (true);
 }

--- a/src/parse_check.c
+++ b/src/parse_check.c
@@ -1,0 +1,93 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_check.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/10/10 09:44:57 by ryhara            #+#    #+#             */
+/*   Updated: 2023/10/10 10:01:25 by ryhara           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parse.h"
+
+bool	check_line(const char *line)
+{
+	size_t	i;
+
+	i = 0;
+	while (line[i])
+	{
+		if (line[i] == ',')
+		{
+			if (!ft_isdigit(line[i + 1]) && line[i + 1] != '-'
+				&& line[i + 1] != '+')
+				return (false);
+		}
+		else if (line[i] == ' ')
+		{
+			if (line[i + 1] == '\0' || line[i + 1] == '\n')
+				return (true);
+			if (line[i + 1] != ' ' && !ft_isdigit(line[i + 1])
+				&& line[i + 1] != '-' && line[i + 1] != '+')
+				return (false);
+		}
+		i++;
+	}
+	return (true);
+}
+
+bool	check_exist_a_c_l(t_global_data *data)
+{
+	if (data->ambient_light == NULL)
+		return (free_data_and_puterr(data, "A does not exist"), false);
+	if (data->camera == NULL)
+		return (free_data_and_puterr(data, "C does not exist"), false);
+	if (data->light == NULL)
+		return (free_data_and_puterr(data, "L does not exist"), false);
+	return (true);
+}
+
+bool	check_vector_valid(char **info, size_t start, size_t end)
+{
+	size_t	i;
+	bool	flag;
+
+	i = start;
+	flag = false;
+	while (i < end)
+	{
+		if (!ft_isdouble(info[i])
+			|| !check_range_float(ft_atof(info[i++]), -1.0, 1.0))
+			return (false);
+	}
+	i = start;
+	while (i < end)
+	{
+		if (ft_atof(info[i]) != 0.0f)
+			flag = true;
+		i++;
+	}
+	return (flag);
+}
+
+char	**parse_check(const char *line)
+{
+	if (!check_line(line))
+		return (NULL);
+	if (!ft_strncmp(MP_AMIBIENT_LIGHT, line, 2))
+		return (parse_ambient_light(line));
+	else if (!ft_strncmp(MP_CAMERA, line, 2))
+		return (parse_camera(line));
+	else if (!ft_strncmp(MP_LIGHT, line, 2))
+		return (parse_light(line));
+	else if (!ft_strncmp(MP_SPHERE, line, 3))
+		return (parse_sphere(line));
+	else if (!ft_strncmp(MP_PLANE, line, 3))
+		return (parse_plane(line));
+	else if (!ft_strncmp(MP_CYLINDER, line, 3))
+		return (parse_cylinder(line));
+	else
+		return (NULL);
+}

--- a/src/parse_objs.c
+++ b/src/parse_objs.c
@@ -6,13 +6,11 @@
 /*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/30 16:19:01 by ryhara            #+#    #+#             */
-/*   Updated: 2023/10/01 15:32:17 by ryhara           ###   ########.fr       */
+/*   Updated: 2023/10/10 10:02:11 by ryhara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parse.h"
-
-void	put_error(const char *name);
 
 char	**parse_sphere(const char *line)
 {
@@ -31,7 +29,7 @@ char	**parse_sphere(const char *line)
 			return (free_char_array(info), NULL);
 		i++;
 	}
-	if (!ft_isdouble(info[4]))
+	if (!ft_isdouble(info[4]) || ft_atof(info[4]) <= 0.0f)
 		return (free_char_array(info), NULL);
 	if (!check_color_range(info, 5, 8))
 		return (free_char_array(info), NULL);
@@ -55,13 +53,8 @@ char	**parse_plane(const char *line)
 			return (free_char_array(info), NULL);
 		i++;
 	}
-	while (i < 7)
-	{
-		if (!ft_isdouble(info[i])
-			|| !check_range_float(ft_atof(info[i]), -1.0, 1.0))
-			return (free_char_array(info), NULL);
-		i++;
-	}
+	if (!check_vector_valid(info, 4, 7))
+		return (free_char_array(info), NULL);
 	if (!check_color_range(info, 7, 10))
 		return (free_char_array(info), NULL);
 	return (info);
@@ -83,13 +76,10 @@ char	**parse_cylinder(const char *line)
 		if (!ft_isdouble(info[i++]))
 			return (free_char_array(info), NULL);
 	}
-	while (i < 7)
-	{
-		if (!ft_isdouble(info[i])
-			|| !check_range_float(ft_atof(info[i++]), -1.0, 1.0))
-			return (free_char_array(info), NULL);
-	}
-	if (!ft_isdouble(info[7]) || !ft_isdouble(info[8]))
+	if (!check_vector_valid(info, 4, 7))
+		return (free_char_array(info), NULL);
+	if (!ft_isdouble(info[7]) || !ft_isdouble(info[8])
+		|| ft_atof(info[7]) <= 0.0f || ft_atof(info[8]) <= 0.0f)
 		return (free_char_array(info), NULL);
 	if (!check_color_range(info, 9, 12))
 		return (free_char_array(info), NULL);

--- a/src/parse_settings.c
+++ b/src/parse_settings.c
@@ -6,13 +6,11 @@
 /*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/30 17:04:51 by ryhara            #+#    #+#             */
-/*   Updated: 2023/10/01 15:34:19 by ryhara           ###   ########.fr       */
+/*   Updated: 2023/10/10 10:02:37 by ryhara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parse.h"
-
-void	put_error(const char *name);
 
 char	**parse_ambient_light(const char *line)
 {
@@ -49,14 +47,10 @@ char	**parse_camera(const char *line)
 			return (free_char_array(info), NULL);
 		i++;
 	}
-	while (i < 7)
-	{
-		if (!ft_isdouble(info[i])
-			|| !check_range_float(ft_atof(info[i]), -1.0, 1.0))
-			return (free_char_array(info), NULL);
-		i++;
-	}
-	if (!ft_isint(info[7]) || !check_range_int(ft_atoi(info[7]), 0, 180))
+	if (!check_vector_valid(info, 4, 7))
+		return (free_char_array(info), NULL);
+	if (!ft_isint(info[7]) || !check_range_int(ft_atoi(info[7]), 0, 180)
+		|| ft_atoi(info[7]) == 0)
 		return (free_char_array(info), NULL);
 	return (info);
 }

--- a/src/parse_utils.c
+++ b/src/parse_utils.c
@@ -6,7 +6,7 @@
 /*   By: ryhara <ryhara@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/30 16:35:48 by ryhara            #+#    #+#             */
-/*   Updated: 2023/09/30 18:00:03 by ryhara           ###   ########.fr       */
+/*   Updated: 2023/10/10 09:49:16 by ryhara           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,21 +36,6 @@ size_t	get_array_size(char **array)
 	while (array[i])
 		i++;
 	return (i);
-}
-
-void	free_char_array(char **array)
-{
-	size_t	i;
-
-	i = 0;
-	while (array[i])
-	{
-		free(array[i]);
-		array[i] = NULL;
-		i++;
-	}
-	free(array);
-	array = NULL;
 }
 
 bool	check_color_range(char **info, size_t start, size_t end)


### PR DESCRIPTION
ベクトルが0,0,0や直径や高さが0の場合をエラーとしました。
また[, <sp>] [,,] [<sp>,]のケースが許容されていたため、check_line関数でエラーとするようにしました。
norm 対策として関数分割をしたため、ファイル分割やheaderを修正しました。headerはファイルごとに関数を分かりやすく配置しました。
norm はparse.cの25行超えが一つあるのみで、その他のparse系のnormは修正しました。

files/ng/double*, files/ng/〇〇_in_〇〇 のケースのみエラーとなっていない状況です。
double＊は先日も話し合ったようにエラーではないということで良いと思います。
◯_in_◯は今後の実装で状況も変わってくると思うので一旦保留で良いかと思います。